### PR TITLE
:whale: added: nginx-proxy & letsencrypt companion to docker-compose

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,11 +63,14 @@ Administrators must add an A record to their DNS configuration that points to th
 
 ## Webapp Environment variables
 
--   KEY_NAME is the name given to the cert & key files used by the Service Provider (e.g:  myservice ). When updated, the names in the *volumes* tag of the *docker-compose-prod.yml* need to be updated too.
--   IDP_METADATA is the public url where the SAML package gets the Identity Provider metadata.
--   SP_URL is the root url of the Service Provider
--   API_HOST is the hostname of the API. It is based on the docker image name.
--   MAIN_URI is used to specify the required prefix for the webapp. Default is ctivalidator.
+-   `KEY_NAME` is the name given to the cert & key files used by the Service Provider (e.g:  myservice ). When updated, the names in the *volumes* tag of the *docker-compose-prod.yml* need to be updated too.
+-   `IDP_METADATA` is the public url where the SAML package gets the Identity Provider metadata.
+-   `SP_URL` is the root url of the Service Provider
+-   `API_HOST` is the hostname of the API. It is based on the docker image name.
+-   `MAIN_URI` is used to specify the required prefix for the webapp. Default is ctivalidator.
+-   `VIRTUAL_HOST` is used by `nginx-proxy` to identify the domain name associated to the Webapp's Docker.
+-   `LETSENCRYPT_HOST` is used by Let'sEncrypt to provide HTTPS support.
+-   `LETSENCRYPT_EMAIL` is used as contact email for Let'sEncrypt staff to send certifcate expiration notices.
 
 ## Frameworks & softwares
 

--- a/README.md
+++ b/README.md
@@ -47,6 +47,20 @@ Optional :
 
 -   HTTP(S)_PROXY are environment variables used to specified a forward proxy for connection to pass through.
 
+## HTTPS support
+
+HTTPS support is provided via the docker images `jwilder/nginx-proxy`, `jrcs/nginx-proxy-lets-encrypt-companion` and
+[Let's Encrypt](https://letsencrypt.org/). The `nginx-proxy` image faces Internet and dispatches requests to the
+concerned service. Services that are reached from the Internet must have the following environment variables :  
+   
+  - `VIRTUAL_HOST` : The domain name associated to the service.  
+  - `LETSENCRYPT_HOST` : Same value as above, used by Let's Encrypt `certbot` to provide certificates.  
+  - `LETSENCRYPT_EMAIL` : Contact email for LetsEncrypt, used to notice certificate expiration. Note that certificates are automatically renewed while the companion is up.  
+
+Administrators must add an A record to their DNS configuration that points to the IP of the machine that hosts
+`nginx/proxy`. HTTPS should then be available in less than 5 minutes (time for Let'sEncrypt bot to provide certificates). 
+   
+
 ## Webapp Environment variables
 
 -   KEY_NAME is the name given to the cert & key files used by the Service Provider (e.g:  myservice ). When updated, the names in the *volumes* tag of the *docker-compose-prod.yml* need to be updated too.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -32,3 +32,31 @@ services:
   squid.forward:
     image: wernight/squid
     container_name: squid.forward
+
+# SSL Let's Encrypt config
+
+  nginx-proxy:
+    image: jwilder/nginx-proxy
+    ports:
+      - "80:80"
+      - "443:443"
+    volumes:
+      - /var/run/docker.sock:/tmp/docker.sock:ro
+      - /etc/letsencrypt/live/example.com:/etc/nginx/certs:ro # Edit path to right domain name
+      - /etc/nginx/vhost.d
+      - /usr/share/nginx/html
+    labels:
+      - com.github.jrcs.letsencrypt_nginx_proxy_companion.nginx_proxy
+
+  nginx-proxy-letsencrypt-companion:
+    image: jrcs/letsencrypt-nginx-proxy-companion
+    volumes:
+      - /etc/letsencrypt/live/example.com:/etc/nginx/certs:rw # Edit path to right domain name
+      - /var/run/docker.sock:/var/run/docker.sock:ro
+    environment:
+      - "FILES_PERMS=600"
+    volumes_from:
+      - nginx-proxy
+
+# Add these env vars to services that need to be reached from the Internet
+# VIRTUAL_HOST=example.com ; LETSENCRYPT_HOST=example.com ; LETSENCRYPT_EMAIL= foo@example.com


### PR DESCRIPTION
This PR adds nginx-proxy & nginx-proxy-letsencrypt-companion to base `docker-compose.yml` files. Its intent is to provide automatic TLS (https) certs provided by Let's Encrypt. The docker image `jwilder/nginx-proxy` faces the internet on ports 80 and 443. It will redirect requests from domain names to the right container provided that the container has the `VIRTUAL_HOST`, `LETSENCRYPT_HOST` and `LETSENCRYPT_EMAIL` env variables set.

Certs provided by LetsEncrypt are available in a mounted volume in the host `/etc/letsencrypt/live/<DomainName>`. The permissions on the certs can be changed via the env var `FILES_PERMS`.